### PR TITLE
Fix Markdown parsing error due to line breaks in generated HTML

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.js]
+insert_final_newline = true

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,22 +1,13 @@
-module.exports = function( eleventyConfig, pluginNamespace ) {
-	eleventyConfig.namespace( pluginNamespace, () => {
-		
-		eleventyConfig.addShortcode( 'respimg', function( src, alt, sizes ) {
-			
-			const fetchBase = `https://res.cloudinary.com/${ eleventyConfig.cloudinaryCloudName }/image/fetch/`;
-			
-			return `<img
-	srcset="${
-		eleventyConfig.srcsetWidths.map( ( w ) => {
-			return `${ fetchBase }q_auto,f_auto,w_${ w }/${ src } ${ w }w`
-		} ).join( ', ' )
-	}"
-	sizes="${ sizes ? sizes : '100vw' }"
-	src="${ fetchBase }q_auto,f_auto,w_${ eleventyConfig.fallbackWidth }/${ src }"
-	${ alt ? `alt="${ alt }"` : '' }
-/>`;
-		
-		} );
-	
-	} );
+module.exports = function (eleventyConfig, pluginNamespace) {
+  eleventyConfig.namespace(pluginNamespace, () => {
+    eleventyConfig.addShortcode('respimg', (path, alt, sizes) => {
+      const fetchBase = `https://res.cloudinary.com/${eleventyConfig.cloudinaryCloudName}/image/fetch/`;
+      const src = `${fetchBase}q_auto,f_auto,w_${eleventyConfig.fallbackWidth}/${path}`;
+      const srcset = eleventyConfig.srcsetWidths.map(w => {
+        return `${fetchBase}q_auto,f_auto,w_${w}/${path} ${w}w`;
+      }).join(', ');
+
+      return `<img src="${src}" srcset="${srcset}" sizes="${sizes ? sizes : '100vw'}" alt="${alt ? alt : ''}">`;
+    });
+  });
 };


### PR DESCRIPTION
👋🏻 Hey Eric, been a while! Hope you are well ☺️

I’m trying out Cloudinary (as Imgix is burning a hole in my pocket), and seeing as my blog uses 11ty, thought I’d give your plugin a go — it’s made transitioning much easier than it would be otherwise. However, it was generating the following error:

```
Problem writing Eleventy templates: (full stack in DEBUG output)
> Parse Error: <img
	srcset="https://res.cloudinary.com/paulrobertlloyd/image/fetch/q_auto,f_auto,w_320/https://paulrobertlloyd.com/images/2008/09/california_zephyr.jpg 320w, https://res.cloudinary.com/paulrobertlloyd/image/fetch/q_auto,f_auto,w_640/https://paulrobertlloyd.com/images/2008/09/california_zephyr.jpg 640w, https://res.cloudinary.com/paulrobertlloyd/image/fetch/q_auto,f_auto,w_960/https://paulrobertlloyd.com/images/2008/09/california_zephyr.jpg 960w, https://res.cloudinary.com/paulrobertlloyd/image/fetch/q_auto,f_auto,w_1280/https://paulrobertlloyd.com/images/2008/09/california_zephyr.jpg 1280w, https://res.cloudinary.com/paulrobertlloyd/image/fetch/q_auto,f_auto,w_1600/https://paulrobertlloyd.com/images/2008/09/california_zephyr.jpg 1600w, https://res.cloudinary.com/paulrobertlloyd/image/fetch/q_auto,f_auto,w_1920/https://paulrobertlloyd.com/images/2008/09/california_zephyr.jpg 1920w"
	sizes="100vw"
	src="https://res.cloudinary.com/paulrobertlloyd/image/fetch/q_auto,f_auto,w_640/https://paulrobertlloyd.com/images/2008/09/california_zephyr.jpg"
<p>/&gt;</p>
  <figcaption>
    <p>The landscape you travel across is one of the most scenic routes run by Amtrak.</p>
  </figcaption>
</figure>
<p>The California Zephyr is a 56 hour, 2348 mile long train journey…
```

Note how the `/>` was output as `<p>/&gt;</p>`? I think 11ty’s Markdown parser is upset by the line breaks. I updated the plugin to fix this error while refactoring the code a little to make the returned statement shorter. I also tidied up a few other bits here and there (removing spaces around values, consistent use of `=>` etc., etc.).

I also added a `.editorconfig` file, which uses the same settings as the main 11ty project. This change (and my syntax formatting) maybe contentious! In which case, feel free to say; I can update this PR to limit it to generating line-break free HTML.

Happy new year!