### PR TITLE
Adds Lazy loading functionality based on global config value

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,7 +7,7 @@ module.exports = function (eleventyConfig, pluginNamespace) {
         return `${fetchBase}q_auto,f_auto,w_${w}/${path} ${w}w`;
       }).join(', ');
 
-      return `<img src="${src}" srcset="${srcset}" sizes="${sizes ? sizes : '100vw'}" alt="${alt ? alt : ''}">`;
+      return `<img src="${src}" srcset="${srcset}" sizes="${sizes ? sizes : '100vw'}" alt="${alt ? alt : ''}" ${eleventyConfig.lazyLoad ? 'loading="lazy"' : ""}>`;
     });
   });
 };

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ module.exports = function( eleventyConfig ) {
 	eleventyConfig.cloudinaryCloudName = 'your-cloud-name-here';
 	eleventyConfig.srcsetWidths = [ 320, 640, 960, 1280, 1600, 1920, 2240, 2560 ];
 	eleventyConfig.fallbackWidth = 640;
-
+	eleventyConfig.lazyLoad = true; // Optional boolean to configure native browser image lazy loading
 	// ③
 	eleventyConfig.addPlugin( pluginRespimg );
 	


### PR DESCRIPTION
When I was working on implementing your plugin for my blog, I wanted to go a step further and have my images take advantage of native browser lazy loading. I've got a local version of the plugin on my site right now, but I think other people might enjoy the option. Bringing it in under a config value means that it can be opt-in for folks.