### PR TITLE
Adds extra argument for appending classes to the img tag returned

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,13 +1,13 @@
 module.exports = function (eleventyConfig, pluginNamespace) {
   eleventyConfig.namespace(pluginNamespace, () => {
-    eleventyConfig.addShortcode('respimg', (path, alt, sizes) => {
+    eleventyConfig.addShortcode('respimg', (path, alt, sizes, classList="") => {
       const fetchBase = `https://res.cloudinary.com/${eleventyConfig.cloudinaryCloudName}/image/fetch/`;
       const src = `${fetchBase}q_auto,f_auto,w_${eleventyConfig.fallbackWidth}/${path}`;
       const srcset = eleventyConfig.srcsetWidths.map(w => {
         return `${fetchBase}q_auto,f_auto,w_${w}/${path} ${w}w`;
       }).join(', ');
 
-      return `<img src="${src}" srcset="${srcset}" sizes="${sizes ? sizes : '100vw'}" alt="${alt ? alt : ''}">`;
+      return `<img src="${src}" srcset="${srcset}" sizes="${sizes ? sizes : '100vw'}" alt="${alt ? alt : ''}" ${classList ? 'class="' + classList + '"' : ""}>`;
     });
   });
 };


### PR DESCRIPTION
While implementing this on my site, I realized there wasn't a way to add a class to the <img> tag rendered by the plugin (which I use classes on `img` a decent bit).

I'm not a huge fan of adding a ton of arguments to universal shortcodes, but I feel like an additional optional classname at the end wouldn't be too far and would extend the functionality a lot.